### PR TITLE
make twig2.options so it can be different from twig.options

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,13 +7,14 @@
     <parameters>
         <parameter key="twig2.class">Twig_Environment</parameter>
         <parameter key="twig2.loader.class">LK\TwigstringBundle\Loader\String</parameter>
+        <parameter key="twig2.options">%twig.options%</parameter>
         <parameter key="templating.engine.twig2.class">Symfony\Bundle\TwigBundle\TwigEngine</parameter>
     </parameters>
 
     <services>
         <service id="twig2" class="%twig2.class%" public="false">
             <argument type="service" id="twig2.loader" />
-            <argument>%twig.options%</argument>
+            <argument>%twig2.options%</argument>
         </service>
 
         <service id="twig2.loader" class="%twig2.loader.class%" public="false">


### PR DESCRIPTION
It's useful to be able to have the options for TwigstringBundle be different from those for your main Twig—for example, if you don't want autoescape for the string-based templates you're using. This patch creates a twig2.options parameter that defaults to be the same as twig.options but can be overridden in the configuration from app.
